### PR TITLE
Use no SSO

### DIFF
--- a/hip2slack_emoji/problem.py
+++ b/hip2slack_emoji/problem.py
@@ -69,7 +69,7 @@ class EmojiImporter(object):
         self.browser = Browser('chrome')
         browser = self.browser
 
-        url = 'https://{}.slack.com/?redir=/customize/emoji'
+        url = 'https://{}.slack.com/?redir=/customize/emoji&no_sso=1'
         url = url.format(self.slack_team)
         browser.visit(url)
 


### PR DESCRIPTION
By default you are given option to login with google or username and password by providing no_sso it will go straight to email/password login which is required for this to work.